### PR TITLE
Set nscd template variables to lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nscd cookbook.
 
 ## Unreleased
 
+- Set nscd template variables to lazy
+
 ## 6.0.3 - *2022-02-08*
 
 - Remove delivery folder

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,8 +29,8 @@ template '/etc/nscd.conf' do
   group 'root'
   mode '0644'
   variables(
-    settings: node['nscd'],
-    databases: sanitize_databases(node['nscd']['databases'])
+    settings: lazy { node['nscd'] },
+    databases: lazy { sanitize_databases(node['nscd']['databases']) }
   )
   cookbook node['nscd']['template_cookbook']
   notifies :restart, 'service[nscd]'


### PR DESCRIPTION
# Description

Currently unable to override nscd attributes from a recipe later in the run_list. By setting the nscd.conf template variables to [Lazy Evaluation](https://docs.chef.io/resource_common/#lazy-evaluation) this waits until after all compile time overrides have completed.

While adding overrides in attribute files, in policies or earlier in the run_list works, this change allows more flexibility.

## Issues Resolved

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
